### PR TITLE
Merge the fix for View Saved Books duplication bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,16 +25,6 @@
     </section>
     <section class="view saved-view hidden">
       <section class="saved-covers-section">
-        <!-- <section class="mini-cover">
-          <img class="cover-image" src="./assets/prairie.jpg">
-          <div class="cover-title">Test Title</div>
-          <div class="tagline">A tale of <span class="tagline-1">passion</span> and <span class="tagline-2">woe</span></div>
-        </section>
-        <section class="mini-cover">
-          <img class="cover-image" src="./assets/prairie.jpg">
-          <div class="cover-title">Test Title</div>
-          <div class="tagline">A tale of <span class="tagline-1">passion</span> and <span class="tagline-2">woe</span></div>
-        </section> -->
       </section>
     </section>
     <section class="view form-view hidden">

--- a/src/main.js
+++ b/src/main.js
@@ -60,10 +60,9 @@ function saveCover() {
       return
     };
   }
-  savedCovers.push(currentCover)
+  savedCovers.push(currentCover);
+  appendCover(currentCover);
 };
-
-
 
 function getCover(e) {
   covers.push(coverInput.value);
@@ -88,16 +87,7 @@ function getCover(e) {
   e.preventDefault();
 }
 
-/* 
-<section class="mini-cover">
-  <img class="cover-image" src="./assets/prairie.jpg">
-  <div class="cover-title">Test Title</div>
-  <div class="tagline">A tale of <span class="tagline-1">passion</span> and <span class="tagline-2">woe</span></div>
-</section> 
-*/
-
-function displayCovers() {
-  savedCoverSection.innerHTML = "";
+function loadCover() {
   for(var i = 0; i < savedCovers.length; i++) {
     appendCover(savedCovers[i]);
   }
@@ -158,8 +148,6 @@ function setSaved() {
   buttonRandomCover.classList.add('hidden');
   buttonSaveCover.classList.add('hidden');
   buttonHome.classList.remove('hidden');
-
-  displayCovers();
 }
 
 //<><>functions<><>
@@ -190,4 +178,5 @@ function randomCover() {
     );
 }
 
+loadCover();
 init();


### PR DESCRIPTION
I changed the logic of appendBooks() to occur only on page load, and when a book is saved. This avoids a bug and saves on memory usage.

In previous versions, the code would append every book onto view saved books page and caused duplications issues when loading the page multiple times. This was solved by reseting the innerHTML of the section each time it was loaded. While, this solution works, it has a problem of constantly needing to append books to the view saved books page each time it loads which seemed unnecessary.

The code now only appendBooks on page load, to add any books stored, and when a book is saved so that way it automatically shows up when un-hidden by setSave(). Covers will only be appended at most once.